### PR TITLE
Change debug & utf8 parameters via options

### DIFF
--- a/lib/gateway/sms77.rb
+++ b/lib/gateway/sms77.rb
@@ -58,8 +58,8 @@ module RubySms
           text:  options[:text].force_encoding('utf-8'),
           to: 	 options[:to],
           delay: options[:delay] || 0,
-          debug: 0,
-          utf8:  1,
+          debug: options[:debug] || 0,
+          utf8:  options[:utf8] || 1,
           u: user,
           p: api_key
         )


### PR DESCRIPTION
The debug parameter is more important for app testing then else. Otherwise we are forced to send real texts.